### PR TITLE
Android Studio 3.0.0 Default Gradle Wrapper needs Maven Google Repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.0'
@@ -16,6 +17,7 @@ allprojects {
     repositories {
         jcenter()
         maven { url "https://www.jitpack.io" }
+        google()
     }
 }
 


### PR DESCRIPTION
If you update to Android Studio 3.0.0 and using Gradle 3.0.0 > and use the default gradle wrapper; you need to include Google's Maven repository in build.gradle. Just solves one type of dev env problem. :)